### PR TITLE
In BuilderDsl, ensure `respond_to?` is consistent with `method_missing`

### DIFF
--- a/lib/stupidedi/builder/builder_dsl.rb
+++ b/lib/stupidedi/builder/builder_dsl.rb
@@ -24,6 +24,10 @@ module Stupidedi
                                  Reader::SegmentDict.empty)
       end
 
+      def respond_to_missing?(name, include_private = false)
+        SEGMENT_ID =~ name.to_s || super
+      end
+
       def strict?
         @strict
       end

--- a/spec/examples/integration/generating.example
+++ b/spec/examples/integration/generating.example
@@ -12,6 +12,16 @@ describe "Generating" do
       expect(lambda { relaxed.xyz }).to \
         raise_error(NoMethodError)
     end
+
+    it "does not respond to invalid segment name" do
+      expect(relaxed.respond_to?(:bad_segment_name)).to be false
+    end
+  end
+
+  context "recognized methods" do
+    it "responds to valid segment name" do
+      expect(relaxed.respond_to?(:ISA)).to be true
+    end
   end
 
   context "unrecognized interchange version" do


### PR DESCRIPTION
When I used a [delegator](http://ruby-doc.org/stdlib-2.1.5/libdoc/delegate/rdoc/Delegator.html) to delegate method calls to a `BuilderDsl` instance, I get:
```
NoMethodError:
       undefined method `ISA' for #<Stupidedi::Builder::BuilderDsl:0x3f9c6a85c5f0 ...>
```
This was because `builder_dsl.respond_to?(:ISA)` returns `false`, but it should return `true` instead.

This change was made to ensure the behavior of `respond_to?` and `method_missing` are consistent.
This change is compatible for ruby 1.9.2 onwards since `respond_to_missing?` is introduced in 1.9.2