### PR TITLE
undo changes to blank

### DIFF
--- a/lib/ruby/blank.rb
+++ b/lib/ruby/blank.rb
@@ -16,24 +16,24 @@ class String
   end
 end
 
-# module Enumerable
-#
-#   # True if the collection is `empty?`
-#   #
-#   # @example
-#   #   [1,2].blank?    #=> false
-#   #   [].blank?       #=> false
-#   #
-#   unless respond_to?(:blank?)
-#
-#   def blank?
-#     empty?
-#   end
-#
-#   def present?
-#     not empty?
-#   end
-# end
+module Enumerable
+
+  # True if the collection is `empty?`
+  #
+  # @example
+  #   [1,2].blank?    #=> false
+  #   [].blank?       #=> false
+  #
+  unless respond_to?(:blank?)
+    def blank?
+      empty?
+    end
+  end
+
+  def present?
+    not empty?
+  end
+end
 
 class NilClass
 


### PR DESCRIPTION
I do not really know why blank is defined (rather than from some standard ruby library), but I do know that reverting this fixes an issue I have been seeing where simply including this gem (without actively using it) causes many of my tests to break with infinite deprecation warnings:

"DEPRECATION WARNING: Passing options to #find is deprecated. Please build a scope and then call #find on it"

and

"DEPRECATION WARNING: Relation#calculate with finder options is deprecated. Please build a scope and then call calculate on it instead."


