### PR TITLE
Add optional elements to TD1 + TD5 segment definitions

### DIFF
--- a/lib/stupidedi/versions/functional_groups/004010/element_defs.rb
+++ b/lib/stupidedi/versions/functional_groups/004010/element_defs.rb
@@ -5912,6 +5912,10 @@ module Stupidedi
           E646  = t:: R.new(:E646 , "Quantity Shipped to Date"             , 1, 9)
           E648  = t::ID.new(:E648 , "Price Multiplier Qualifier"           , 3, 3)
           E649  = t:: R.new(:E649 , "Multiplier"                           , 1, 10)
+          E662  = t::ID.new(:E662 , "Relationship Code"                    , 1, 1,
+            s::CodeList.build(
+              "I" => "Included"))
+
           E665  = t::ID.new(:E665 , "Residue Indicator Code"               , 1, 1,
             s::CodeList.build(
               "G" => "Residue Last Contained Description (Small Means of Containment)",

--- a/lib/stupidedi/versions/functional_groups/004010/element_defs.rb
+++ b/lib/stupidedi/versions/functional_groups/004010/element_defs.rb
@@ -6180,7 +6180,8 @@ module Stupidedi
               "O"   => "Order",
               "S"  => "Shipment",
               "T"  => "Shipping Tare",
-              "P"  => "Pack"))
+              "P"  => "Pack",
+              "K"  => "Kit"))
 
           E736  = t::ID.new(:E736 , "Hierarchical Child Code"              , 1, 1,
             s::CodeList.build(

--- a/lib/stupidedi/versions/functional_groups/004010/element_defs.rb
+++ b/lib/stupidedi/versions/functional_groups/004010/element_defs.rb
@@ -4037,6 +4037,7 @@ module Stupidedi
               "ER" => "Jurisdiction Specific Procedure and Supply Codes",
               "HC" => "Health Care Financing Administration Common Procedural Coding System (HCPCS) Codes",
               "ID" => "International Classification of Diseases Clinical Modification (ICD-9-CM) - Procedure",
+              "IN" => "Buyer's Item Number",
               "IV" => "Home Infusion EDI Coalition (HIEC) Product/Service Code",
               "MG" => "Manufacturer's Part Number",
               "N1" => "National Drug Code in 4-4-2 Format",

--- a/lib/stupidedi/versions/functional_groups/004010/element_defs.rb
+++ b/lib/stupidedi/versions/functional_groups/004010/element_defs.rb
@@ -64,7 +64,7 @@ module Stupidedi
           E60   = t:: R.new(:E60  , "Freight Rate"                         , 1, 9)
           E61   = t::AN.new(:E61  , "Free-Form Message"                    , 1, 30)
           E65   = t:: R.new(:E65  , "Height"                               , 1, 8)
-          E66   = t::ID.new(:E66  , "Identification Code Qualifier"        , 2, 3,
+          E66   = t::ID.new(:E66  , "Identification Code Qualifier"        , 1, 3,
             s::CodeList.build(
               "1"  => "D-U-N-S Number, Dun & Bradstreet",
               "2"  => "Standard Carrier Alpha Code (SCAC)",

--- a/lib/stupidedi/versions/functional_groups/004010/element_defs.rb
+++ b/lib/stupidedi/versions/functional_groups/004010/element_defs.rb
@@ -6176,6 +6176,7 @@ module Stupidedi
               "23" => "Dependent",
               "PT" => "Patient",
               "I"  => "Item",
+              "O"   => "Order",
               "S"  => "Shipment",
               "T"  => "Shipping Tare",
               "P"  => "Pack"))

--- a/lib/stupidedi/versions/functional_groups/004010/element_defs.rb
+++ b/lib/stupidedi/versions/functional_groups/004010/element_defs.rb
@@ -4047,6 +4047,7 @@ module Stupidedi
               "ND" => "National Drug Code (NDC)",
               "NU" => "National Uniform Billing Committee (NUBC) UB92 Codes",
               "RB" => "National Uniform Billing Committee (NUBC) UB82 Codes",
+              "SN" => "Serial Number",
               "UK" => "UPC/EAN Shipping Container Code",
               "UP" => "UPC Consumer Packaging Code",
               "VN" => "Vendor's (Seller's) Item Number",

--- a/lib/stupidedi/versions/functional_groups/004010/segment_defs.rb
+++ b/lib/stupidedi/versions/functional_groups/004010/segment_defs.rb
@@ -193,6 +193,9 @@ module Stupidedi
           autoload :S5,
             "stupidedi/versions/functional_groups/004010/segment_defs/S5"
 
+          autoload :SLN,
+            "stupidedi/versions/functional_groups/004010/segment_defs/SLN"
+
           autoload :SN1,
             "stupidedi/versions/functional_groups/004010/segment_defs/SN1"
 

--- a/lib/stupidedi/versions/functional_groups/004010/segment_defs.rb
+++ b/lib/stupidedi/versions/functional_groups/004010/segment_defs.rb
@@ -181,6 +181,9 @@ module Stupidedi
           autoload :PO4,
             "stupidedi/versions/functional_groups/004010/segment_defs/PO4"
 
+          autoload :PRF,
+            "stupidedi/versions/functional_groups/004010/segment_defs/PRF"
+
           autoload :QTY,
             "stupidedi/versions/functional_groups/004010/segment_defs/QTY"
 

--- a/lib/stupidedi/versions/functional_groups/004010/segment_defs/PRF.rb
+++ b/lib/stupidedi/versions/functional_groups/004010/segment_defs/PRF.rb
@@ -1,0 +1,20 @@
+module Stupidedi
+  module Versions
+    module FunctionalGroups
+      module FortyTen
+        module SegmentDefs
+
+          s = Schema
+          e = ElementDefs
+          r = ElementReqs
+
+          PRF = s::SegmentDef.build(:PRF, "Purchase Order Reference",
+            "Contains data about the purchase order being filled by this ASN",
+            e::E324.simple_use(r::Mandatory,  s::RepeatCount.bounded(1)),
+            e::E328.simple_use(r::Mandatory,  s::RepeatCount.bounded(1)),
+            e::E373.simple_use(r::Mandatory,  s::RepeatCount.bounded(1)))
+        end
+      end
+    end
+  end
+end

--- a/lib/stupidedi/versions/functional_groups/004010/segment_defs/SLN.rb
+++ b/lib/stupidedi/versions/functional_groups/004010/segment_defs/SLN.rb
@@ -1,0 +1,23 @@
+module Stupidedi
+  module Versions
+    module FunctionalGroups
+      module FortyTen
+        module SegmentDefs
+
+          s = Schema
+          e = ElementDefs
+          r = ElementReqs
+
+          SLN = s::SegmentDef.build(:SLN, "Subline Item Details",
+            "To specify product subline detail item data",
+            e::E350 .simple_use(r::Required,   s::RepeatCount.bounded(1)),
+            e::E662 .simple_use(r::Required,   s::RepeatCount.bounded(1)),
+            e::E380 .simple_use(r::Required,   s::RepeatCount.bounded(1)),
+            e::E355 .simple_use(r::Required,   s::RepeatCount.bounded(1)),
+            e::E235 .simple_use(r::Required,   s::RepeatCount.bounded(1)))
+            e::E234 .simple_use(r::Required,   s::RepeatCount.bounded(1)))
+        end
+      end
+    end
+  end
+end

--- a/lib/stupidedi/versions/functional_groups/004010/segment_defs/TD1.rb
+++ b/lib/stupidedi/versions/functional_groups/004010/segment_defs/TD1.rb
@@ -13,9 +13,10 @@ module Stupidedi
           TD1 = s::SegmentDef.build(:TD1, "Carrier Details (Quantity and Weight)",
             "To specify the transportation details relative to commodity, weight, and quantity",
             e::E103 .simple_use(r::Mandatory,  s::RepeatCount.bounded(1)),
-           #e::C103 .simple_use(r::Mandatory,  s::RepeatCount.bounded(1)),
-            e::E80  .simple_use(r::Mandatory,  s::RepeatCount.bounded(1)))
-
+            e::E80  .simple_use(r::Mandatory,  s::RepeatCount.bounded(1)),
+            e::E187 .simple_use(r::Optional,   s::RepeatCount.bounded(1)),
+            e::E81  .simple_use(r::Optional,   s::RepeatCount.bounded(1)),
+            e::E355 .simple_use(r::Optional,   s::RepeatCount.bounded(1)))
         end
       end
     end

--- a/lib/stupidedi/versions/functional_groups/004010/segment_defs/TD5.rb
+++ b/lib/stupidedi/versions/functional_groups/004010/segment_defs/TD5.rb
@@ -11,7 +11,7 @@ module Stupidedi
           TD5 = s::SegmentDef.build(:TD5, "Carrier Details (Routing Sequence/Transit Time)",
             "To specify the carrier and sequence of routing and provide transit time information",
             e::E133.simple_use(r::Optional,  s::RepeatCount.bounded(1)),
-            e::E66 .simple_use(r::Mandatory,  s::RepeatCount.bounded(1)),
+            e::E66 .simple_use(r::Relational, s::RepeatCount.bounded(1)),
             e::E67 .simple_use(r::Mandatory,  s::RepeatCount.bounded(1)),
             e::E91 .simple_use(r::Relational, s::RepeatCount.bounded(1)),
             e::E387.simple_use(r::Optional,  s::RepeatCount.bounded(1)))

--- a/lib/stupidedi/versions/functional_groups/004010/segment_defs/TD5.rb
+++ b/lib/stupidedi/versions/functional_groups/004010/segment_defs/TD5.rb
@@ -13,7 +13,8 @@ module Stupidedi
             e::E133.simple_use(r::Optional,  s::RepeatCount.bounded(1)),
             e::E66 .simple_use(r::Mandatory,  s::RepeatCount.bounded(1)),
             e::E67 .simple_use(r::Mandatory,  s::RepeatCount.bounded(1)),
-            e::E91 .simple_use(r::Relational, s::RepeatCount.bounded(1)))
+            e::E91 .simple_use(r::Relational, s::RepeatCount.bounded(1)),
+            e::E387.simple_use(r::Optional,  s::RepeatCount.bounded(1)))
 
         end
       end


### PR DESCRIPTION
I'm totally new to EDI so please correct me if this PR makes no sense, but... we're working on generating EDI for a partner and their TD1 format for a 4010 version 856 transaction set has five elements, which fails because a TD1 for version 4010 TD1 segment is only expected to have two mandatory elements.

This PR allows this data to pass validation but I'm not sure what exactly the "standard" is, and looking around I've seen cases with 5 elements and others with two.