### PR TITLE
the write function does not expect a parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ b.machine.zipper.tap do |z|
   # You can also serialize any subtree within the document (e.g., everything inside
   # some ST..SE transaction set, or a single loop. Here, z.root is the entire tree.
   w = Stupidedi::Writer::Default.new(z.root, separators)
-  w.write($stdout)
+  print w.write()
 end
 ```
 


### PR DESCRIPTION
Without this minor edit this will give the following error:
/var/lib/gems/2.3.0/gems/stupidedi-1.2.12/lib/stupidedi/writer/default.rb:18:in `write': wrong number of arguments (given 1, expected 0) (ArgumentError)
        from write.rb:64:in `block in <main>'
        from /var/lib/gems/2.3.0/gems/stupidedi-1.2.12/lib/stupidedi/either.rb:154:in `deconstruct'
        from /var/lib/gems/2.3.0/gems/stupidedi-1.2.12/lib/stupidedi/either.rb:129:in `tap'