### PR TITLE
Extend max length of "Name Last or Organization Name"

### DIFF
--- a/lib/stupidedi/versions/005010/element_defs.rb
+++ b/lib/stupidedi/versions/005010/element_defs.rb
@@ -2121,7 +2121,7 @@ module Stupidedi
             "PR" => "Patient Responsibility"))
         E1034 = t::ID.new(:E1034, "Claim Adjustment Reason Code"         , 1, 5,
           s::CodeList.external("139"))
-        E1035 = t::AN.new(:E1035, "Name Last or Organization Name"       , 1, 60)
+        E1035 = t::AN.new(:E1035, "Name Last or Organization Name"       , 1, 80)
         E1036 = t::AN.new(:E1036, "Name First"                           , 1, 35)
         E1037 = t::AN.new(:E1037, "Name Middle"                          , 1, 25)
         E1038 = t::AN.new(:E1038, "Name Prefix"                          , 1, 10)


### PR DESCRIPTION
The billing platform we work with has instructed us to use payor names that are longer than 60 characters. When we generate x12 for those, we receive the error: "value is too long in element NM103 Receiver Name".

I've found a few resources that indicate the max length field should be 80 characters, not 60:
https://www.stedi.com/edi/x12-008010/segment/NM1?account=4a37fdae-d1b4-4707-b7cd-8d96e695ddf3
https://ushik.ahrq.gov/ViewItemDetails?&system=apcd&itemKey=196701000