### PR TITLE
Allow 50 char max length in X222A1-HC837 loop 2300 REF D9 segment

### DIFF
--- a/lib/stupidedi/transaction_sets/005010/implementations/X222A1-HC837.rb
+++ b/lib/stupidedi/transaction_sets/005010/implementations/X222A1-HC837.rb
@@ -198,7 +198,7 @@ module Stupidedi
                   b::Element(e::NotUsed,     "REFERENCE IDENTIFIER")),
                 b::Segment(1800, s::REF, "Claim Identifier for Transmission Intermediaries", r::Situational, d::RepeatCount.bounded(1),
                   b::Element(e::Required,    "Reference Identification Qualifier", b::Values("D9")),
-                  b::Element(e::Required,    "Value Added Network Trace Number", b::MaxLength(20)),
+                  b::Element(e::Required,    "Value Added Network Trace Number", b::MaxLength(50)),
                   b::Element(e::NotUsed,     "Description"),
                   b::Element(e::NotUsed,     "REFERENCE IDENTIFIER")),
                 b::Segment(1800, s::REF, "Medical Record Number", r::Situational, d::RepeatCount.bounded(1),


### PR DESCRIPTION
This PR allows values of up to 50 characters in the REF D9 segment in loop 2300 of the X222A1-HC837 implementation of the 005010 transaction set.

According to the 837 Professional spec we have, 50 characters is the limit allowed here (see attached screenshot). Our vendors support 50 character strings in this field and this has been causing issues when we try to export 837 files.
<img width="853" height="1006" alt="D9" src="https://github.com/user-attachments/assets/dca3a51c-d416-47d4-8314-79f682704e89" />
