### PR TITLE
Feature/non determinism fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+v Unreleased
+
+  **Bug fixes**
+
+  * Fix `too much non-determinism` error when a `LoopDef` contains repeated
+    structurally-identical `SegmentUse` slots (same id, no qualifier element)
+    and only the earlier slot is filled — e.g. an N3 in the partner-customised
+    4010 PO850 N1 loop. `ConstraintTable::ValueBased` now consults the active
+    parser state's parse tree to pick the slot whose preceding sibling has
+    actually been consumed: the earliest position past the highest-consumed
+    sibling in the matching parent loop. This requires plumbing the active
+    `AbstractState` through `InstructionTable#matches` and the `ConstraintTable`
+    subclasses' `matches`. Behaviour is unchanged for qualifier-disambiguated
+    paths (e.g. N1 by N101) and for genuinely ambiguous cases across different
+    parent loops. During `find` navigation the `mode == :insert` gate skips
+    disambiguation entirely, so the full candidate set is preserved.
+
 v 1.4.1
 
   **Bug Fixes**

--- a/lib/stupidedi/parser/constraint_table.rb
+++ b/lib/stupidedi/parser/constraint_table.rb
@@ -18,7 +18,7 @@ module Stupidedi
     #
     class ConstraintTable
       # @return [Array<Instruction>]
-      abstract :matches, :args => %w(segment_tok strict mode)
+      abstract :matches, :args => %w(segment_tok strict mode state)
 
       # @return [Array<Instruction>]
       attr_reader :instructions
@@ -60,7 +60,7 @@ module Stupidedi
         end
 
         # @return [Array<Instruction>]
-        def matches(segment_tok, strict, mode)
+        def matches(segment_tok, strict, mode, state = nil)
           @instructions.tap do |xs|
             critique(segment_tok, xs.map(&:segment_use)) if strict
           end
@@ -79,7 +79,7 @@ module Stupidedi
         end
 
         # @return [Array<Instruction>]
-        def matches(segment_tok, strict, mode)
+        def matches(segment_tok, strict, mode, state = nil)
           @__matches ||= begin
             shallowest = @instructions.map(&:pop_count).min
             @instructions.select{|i| i.pop_count == shallowest }.tap do |xs|
@@ -119,7 +119,7 @@ module Stupidedi
         end
 
         # @return [Array<Instruction>]
-        def matches(segment_tok, strict, mode)
+        def matches(segment_tok, strict, mode, state = nil)
           invalid = true  # Were all present possibly distinguishing elements invalid?
           present = false # Were any possibly distinguishing elements present?
 
@@ -201,13 +201,21 @@ module Stupidedi
             # Some elements were present and none were invalid, but it was not
             # possible to narrow the set of matches to a single instruction.
             #
-            # It seems wrong to mark the segment invalid. The worst thing you
-            # could say about the input is that it may have been missing a
-            # required element that could have resolved the ambiguity; but it's
-            # also possible all required elements were present and the grammar
-            # is the problem (not the input). So here we return the remaining
-            # search space, which will cause non-determinism in the parser.
-            space
+            # When the survivors are sibling slots in the same loop sharing a
+            # segment id (e.g. two N3 slots in a partner-customised 4010 PO850
+            # N1 loop), use the parser's current parse tree to pick the slot
+            # whose preceding-sibling structure has actually been entered
+            # (Variant A — structural reachability). The :insert gate skips
+            # disambiguation during :find navigation, where the caller wants
+            # the full set of candidates a segment could be bound to. For
+            # genuinely ambiguous cases (different parent loops, or different
+            # segment ids) the helper bails out to the full search space,
+            # which will cause non-determinism in the parser.
+            if mode == :insert
+              disambiguate_sibling_slots(space, state)
+            else
+              space
+            end
           end
         end
 
@@ -222,6 +230,76 @@ module Stupidedi
             shallowest = is.map(&:pop_count).min
             is.select{|i| i.pop_count == shallowest }
           end
+        end
+
+        # When ValueBased filtering leaves multiple Instructions whose
+        # SegmentUses are sibling slots in the same parent loop sharing a
+        # segment id, pick the slot whose ancestor structure has actually
+        # been entered in the current parse tree. Concretely: among the
+        # candidate sibling positions, keep only those greater than the
+        # highest-position segment already consumed in the parent loop;
+        # then pick the earliest among those. If `state` (and thus the
+        # parse tree) is not available, fall back to picking the earliest
+        # position outright (Variant B). Falls back to the input unchanged
+        # when the precondition fails, preserving the existing non-
+        # determinism error for genuinely ambiguous cases (e.g. survivors
+        # in different parent loops).
+        #
+        # All survivors share a segment id by construction (instructions
+        # are grouped by segment_id in InstructionTable#constraints before
+        # ConstraintTable.build is called).
+        #
+        # @return [Array<Instruction>]
+        def disambiguate_sibling_slots(instructions, state = nil)
+          return instructions if instructions.length <= 1
+
+          collapsed = shallowest(instructions)
+          return collapsed if collapsed.length <= 1
+
+          uses = collapsed.map(&:segment_use)
+          parent = uses.first.parent
+          return instructions if parent.nil?
+          return instructions unless uses.all?{|u| u.parent.equal?(parent) }
+
+          reachable = collapsed
+          highest   = highest_consumed_position(state, parent) if state
+          if highest
+            # Strict `>` assumes non-repeating sibling slots: a candidate
+            # whose position equals `highest` is excluded because that
+            # slot has already been consumed. If a partner grammar exposes
+            # repeating sibling slots, this may need to relax to `>=`.
+            ahead = collapsed.select{|i| i.segment_use.position > highest }
+            reachable = ahead unless ahead.empty?
+          end
+
+          min_pos = reachable.map{|i| i.segment_use.position }.min
+          reachable.select{|i| i.segment_use.position == min_pos }
+        end
+
+        # Walks up from the state's value-tree zipper to find the LoopVal/
+        # TableVal whose definition matches `parent` (object identity), then
+        # returns the highest `usage.position` among its already-consumed
+        # segment children. Returns nil when the matching container can't be
+        # found (e.g. the loop hasn't been opened yet) or has no consumed
+        # segments — both of which mean we have no structural signal to use.
+        #
+        # @return [Integer, nil]
+        def highest_consumed_position(state, parent)
+          return nil if state.nil?
+          z = state.zipper
+          while z
+            node = z.node
+            if (node.loop? or node.table?) and node.definition.equal?(parent)
+              positions = node.children
+                .select{|c| c.segment? and c.usage }
+                .map{|c| c.usage.position }
+              return positions.max if positions.any?
+              return nil
+            end
+            break if z.root?
+            z = z.up
+          end
+          nil
         end
 
         # @return [Array(Array<(Integer, Integer, Map)>, Array<(Integer, Integer, Map)>)]

--- a/lib/stupidedi/parser/generation.rb
+++ b/lib/stupidedi/parser/generation.rb
@@ -57,7 +57,7 @@ module Stupidedi
       def insert(segment_tok, strict, reader)
         active = @active.flat_map do |zipper|
           state        = zipper.node
-          instructions = state.instructions.matches(segment_tok, strict, :insert)
+          instructions = state.instructions.matches(segment_tok, strict, :insert, state)
 
           if instructions.empty?
             zipper.append(FailureState.mksegment(segment_tok, state)).cons

--- a/lib/stupidedi/parser/instruction_table.rb
+++ b/lib/stupidedi/parser/instruction_table.rb
@@ -47,9 +47,9 @@ module Stupidedi
         end
 
         # @return [Array<Instruction>]
-        def matches(segment_tok, strict = false, mode = :insert)
+        def matches(segment_tok, strict = false, mode = :insert, state = nil)
           if constraints.defined_at?(segment_tok.id)
-            constraints.at(segment_tok.id).matches(segment_tok, strict, mode)
+            constraints.at(segment_tok.id).matches(segment_tok, strict, mode, state)
           else
             []
           end
@@ -173,7 +173,7 @@ module Stupidedi
           InstructionTable::NonEmpty.new(instructions, self)
         end
 
-        def matches(segment_tok, strict = false, mode = :insert)
+        def matches(segment_tok, strict = false, mode = :insert, state = nil)
           raise Exceptions::ParseError,
             "empty stack"
         end

--- a/spec/lib/stupidedi/parser/duplicate_slot_spec.rb
+++ b/spec/lib/stupidedi/parser/duplicate_slot_spec.rb
@@ -1,0 +1,370 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+# Reproducer for the non-determinism error that fires when a LoopDef has
+# two structurally-identical SegmentUse slots for the same segment id and
+# the input fills only the earlier slot. See:
+#
+#   ai/tickets/tediparse-04-resolve-duplicate-segment-slot-nondeterminism.md
+#
+# Uses generic placeholder segment ids (:AA, :CC) and a synthetic transaction
+# set "XX*999" registered into a fresh Config so the test is independent of
+# any X12 transaction-set definition.
+describe "Duplicate sibling segment slots in a single loop" do
+  using Stupidedi::Refinements
+
+  let(:b) { Stupidedi::TransactionSets::Builder       }
+  let(:d) { Stupidedi::Schema                          }
+  let(:r) { Stupidedi::Versions::FiftyTen::SegmentReqs }
+  let(:e) { Stupidedi::Versions::FiftyTen::ElementReqs }
+  let(:s) { Stupidedi::Versions::FiftyTen::SegmentDefs }
+
+  # Generic placeholder element types — single-character ID with a code list
+  # of {P, O} lets us discriminate the two opener slots; AN with no code
+  # list keeps the ambiguous slot indiscriminate.
+  let(:de_qualifier) do
+    Stupidedi::Versions::Common::ElementTypes::ID.new(:DE_QUAL, "Qualifier", 1, 1,
+      d::CodeList.internal({"P" => "Primary", "O" => "Override"}))
+  end
+
+  let(:de_text) do
+    Stupidedi::Versions::Common::ElementTypes::AN.new(:DE_TEXT, "Free Text", 1, 30)
+  end
+
+  # Synthetic AA opener: qualifier + free text. Per-use Values("P") / Values("O")
+  # let ValueBased discriminate the two AA SegmentUses in the loop.
+  let(:aa_def) do
+    d::SegmentDef.build(:AA, "AA Opener", "",
+      de_qualifier.simple_use(e::Mandatory, d::RepeatCount.bounded(1)),
+      de_text.simple_use(e::Optional, d::RepeatCount.bounded(1)))
+  end
+
+  # Synthetic CC ambiguous segment: two free-text elements, no code list.
+  # Two CC SegmentUses in the same loop are structurally identical — there
+  # is no element value the parser can use to discriminate them.
+  let(:cc_def) do
+    d::SegmentDef.build(:CC, "CC Ambiguous", "",
+      de_text.simple_use(e::Mandatory, d::RepeatCount.bounded(1)),
+      de_text.simple_use(e::Optional, d::RepeatCount.bounded(1)))
+  end
+
+  # Single loop with two AA opener slots (P-qualified primary, O-qualified
+  # override) and two CC ambiguous slots — mirrors the partner-customised
+  # 4010 PO850 N1 loop from TEDI-422.
+  let(:transaction_set_def) do
+    aa = aa_def
+    cc = cc_def
+
+    b.build("XX", "999", "Test - duplicate slots in one loop",
+      d::TableDef.header("Heading",
+        s::ST.use(100, r::Mandatory, d::RepeatCount.bounded(1)),
+        d::LoopDef.build("L1", d::RepeatCount.bounded(1),
+          b.Segment(200, aa, "Primary Opener", r::Mandatory,
+            d::RepeatCount.bounded(1),
+            b.Element(e::Mandatory, "AA01 Qualifier", b.Values("P")),
+            b.Element(e::Optional,  "AA02 Free Text")),
+          b.Segment(300, cc, "Primary CC", r::Optional,
+            d::RepeatCount.bounded(1),
+            b.Element(e::Mandatory, "CC01 First"),
+            b.Element(e::Optional,  "CC02 Second")),
+          b.Segment(400, aa, "Override Opener", r::Optional,
+            d::RepeatCount.bounded(1),
+            b.Element(e::Mandatory, "AA01 Qualifier", b.Values("O")),
+            b.Element(e::Optional,  "AA02 Free Text")),
+          b.Segment(500, cc, "Override CC", r::Optional,
+            d::RepeatCount.bounded(1),
+            b.Element(e::Mandatory, "CC01 First"),
+            b.Element(e::Optional,  "CC02 Second"))),
+        s::SE.use(600, r::Mandatory, d::RepeatCount.bounded(1))))
+  end
+
+  let(:config) do
+    ts = transaction_set_def
+    Stupidedi::Config.default.customize do |c|
+      c.transaction_set.register("005010", "XX", "999") { ts }
+    end
+  end
+
+  def envelope(body)
+    <<~EDI.gsub("\n", "~")
+      ISA*00*          *00*          *ZZ*SENDER         *ZZ*RECEIVER       *230101*1200*U*00501*000000001*0*P*>
+      GS*XX*SENDER*RECEIVER*20230101*1200*1*X*005010
+      ST*999*0001
+      #{body}
+      SE*99*0001
+      GE*1*1
+      IEA*1*000000001
+    EDI
+  end
+
+  def parse(edi)
+    Stupidedi::Parser.build(config).read(Stupidedi::Reader.build(edi))
+  end
+
+  def first_cc(machine)
+    machine.first
+      .flatmap{|m| m.find(:GS) }
+      .flatmap{|m| m.find(:ST) }
+      .flatmap{|m| m.find(:AA) }
+      .flatmap{|m| m.find(:CC) }
+      .fetch
+  end
+
+  def cc_position(machine)
+    first_cc(machine).zipper.fetch.node.usage.position
+  end
+
+  context "earlier slot only (TEDI-422 reproducer)" do
+    it "parses successfully and binds CC to the earlier-positioned slot" do
+      machine, result = parse(envelope("AA*P*hello\nCC*alpha"))
+
+      if result.fatal?
+        result.explain { |msg| fail "Parse error: #{msg}" }
+      end
+      expect(result).to be_success
+
+      expect(cc_position(machine)).to eq(300)
+    end
+  end
+
+  # Mirrors the real-world PO850 N1 loop shape: the loop is opened by the
+  # primary opener (AA*P at position 200), then a second qualifier-
+  # distinguished opener inside the loop body (AA*O at position 400)
+  # advances the parse into the override block. The override CC must bind
+  # to position 500, even though both CC slots remain candidates from the
+  # constraint table's perspective. This is what Variant A buys over
+  # Variant B: the structural-reachability check uses the parse tree to
+  # see that the cursor has already moved past position 400.
+  context "later slot reached via in-loop opener" do
+    it "binds CC to the later-positioned slot" do
+      machine, result = parse(envelope("AA*P*hello\nAA*O*goodbye\nCC*beta"))
+
+      if result.fatal?
+        result.explain { |msg| fail "Parse error: #{msg}" }
+      end
+      expect(result).to be_success
+      expect(cc_position(machine)).to eq(500)
+    end
+  end
+
+  context "both blocks present" do
+    it "parses successfully and binds each CC to its own slot" do
+      machine, result = parse(envelope("AA*P*hello\nCC*alpha\nAA*O*goodbye\nCC*beta"))
+
+      if result.fatal?
+        result.explain { |msg| fail "Parse error: #{msg}" }
+      end
+      expect(result).to be_success
+
+      # Walk to the first CC, then iterate to the next CC.
+      first  = first_cc(machine)
+      second = first.find(:CC).fetch
+
+      expect(first .zipper.fetch.node.usage.position).to eq(300)
+      expect(second.zipper.fetch.node.usage.position).to eq(500)
+    end
+  end
+
+  # End-to-end guard for the genuinely-ambiguous case: two CC SegmentUses
+  # whose parents are different LoopDef objects. The disambiguation
+  # precondition `parent.equal?` fails, the helper bails out, and the
+  # parser surfaces "too much non-determinism" exactly as it did before
+  # the fix. This proves the precondition correctly trickles out of
+  # disambiguate_sibling_slots into the parser's failure path, not just
+  # the unit test below.
+  context "two same-id slots in different parent loops (genuinely ambiguous)" do
+    let(:ambiguous_transaction_set_def) do
+      cc = cc_def
+
+      b.build("XX", "998", "Test - ambiguous across parent loops",
+        d::TableDef.header("Heading",
+          s::ST.use(100, r::Mandatory, d::RepeatCount.bounded(1)),
+          d::LoopDef.build("LA", d::RepeatCount.bounded(1),
+            b.Segment(200, cc, "LA CC", r::Optional,
+              d::RepeatCount.bounded(1),
+              b.Element(e::Mandatory, "CC01 First"),
+              b.Element(e::Optional,  "CC02 Second"))),
+          d::LoopDef.build("LB", d::RepeatCount.bounded(1),
+            b.Segment(400, cc, "LB CC", r::Optional,
+              d::RepeatCount.bounded(1),
+              b.Element(e::Mandatory, "CC01 First"),
+              b.Element(e::Optional,  "CC02 Second"))),
+          s::SE.use(600, r::Mandatory, d::RepeatCount.bounded(1))))
+    end
+
+    let(:ambiguous_config) do
+      ts = ambiguous_transaction_set_def
+      Stupidedi::Config.default.customize do |c|
+        c.transaction_set.register("005010", "XX", "998") { ts }
+      end
+    end
+
+    def envelope_998(body)
+      <<~EDI.gsub("\n", "~")
+        ISA*00*          *00*          *ZZ*SENDER         *ZZ*RECEIVER       *230101*1200*U*00501*000000001*0*P*>
+        GS*XX*SENDER*RECEIVER*20230101*1200*1*X*005010
+        ST*998*0001
+        #{body}
+        SE*99*0001
+        GE*1*1
+        IEA*1*000000001
+      EDI
+    end
+
+    it "preserves the non-determinism error when survivors have different parents" do
+      _machine, result = Stupidedi::Parser.build(ambiguous_config)
+        .read(Stupidedi::Reader.build(envelope_998("CC*alpha")))
+      expect(result.fatal?).to be true
+      msg = nil
+      result.explain {|m| msg = m }
+      expect(msg).to include("too much non-determinism")
+    end
+  end
+
+  # Mirrors the LoopDef shape supported since commit 7d203a74 — segments
+  # interleaved with child loops. Outer loop layout:
+  #   [AA@200, CC@300, inner_loop@400, CC@500]
+  # After consuming AA*P + the inner loop's BB segment, a CC token must
+  # bind to position 500 (post-inner-loop), not position 300 (pre).
+  #
+  # `highest_consumed_position` only scans segment children of the
+  # matching parent loop, so on its own it would return position 200
+  # (the outer AA) and pick CC@300 — wrong. This case nonetheless
+  # works because `InstructionTable#drop_count` prunes CC@300 from the
+  # candidate set when the parser advances past the inner loop, so by
+  # the time the CC token arrives `disambiguate_sibling_slots` is not
+  # called at all (single-instruction `Stub` is selected upstream in
+  # `ConstraintTable.build`). This spec locks in that interaction:
+  # if a future change to the InstructionTable mechanism stops pruning,
+  # this test will fail and the watermark logic will need to consider
+  # consumed sibling LoopVals.
+  context "interleaved child loop between two same-id sibling slots" do
+    let(:bb_def) do
+      d::SegmentDef.build(:BB, "BB Inner Opener", "",
+        de_text.simple_use(e::Mandatory, d::RepeatCount.bounded(1)))
+    end
+
+    let(:interleaved_transaction_set_def) do
+      aa = aa_def
+      bb = bb_def
+      cc = cc_def
+
+      b.build("XX", "997", "Test - interleaved child loop",
+        d::TableDef.header("Heading",
+          s::ST.use(100, r::Mandatory, d::RepeatCount.bounded(1)),
+          d::LoopDef.build("L1", d::RepeatCount.bounded(1),
+            b.Segment(200, aa, "Outer Opener", r::Mandatory,
+              d::RepeatCount.bounded(1),
+              b.Element(e::Mandatory, "AA01 Qualifier", b.Values("P")),
+              b.Element(e::Optional,  "AA02 Free Text")),
+            b.Segment(300, cc, "Pre-loop CC", r::Optional,
+              d::RepeatCount.bounded(1),
+              b.Element(e::Mandatory, "CC01 First"),
+              b.Element(e::Optional,  "CC02 Second")),
+            d::LoopDef.build("L1A", d::RepeatCount.bounded(1),
+              b.Segment(400, bb, "Inner Opener", r::Mandatory,
+                d::RepeatCount.bounded(1),
+                b.Element(e::Mandatory, "BB01 First"))),
+            b.Segment(500, cc, "Post-loop CC", r::Optional,
+              d::RepeatCount.bounded(1),
+              b.Element(e::Mandatory, "CC01 First"),
+              b.Element(e::Optional,  "CC02 Second"))),
+          s::SE.use(600, r::Mandatory, d::RepeatCount.bounded(1))))
+    end
+
+    let(:interleaved_config) do
+      ts = interleaved_transaction_set_def
+      Stupidedi::Config.default.customize do |c|
+        c.transaction_set.register("005010", "XX", "997") { ts }
+      end
+    end
+
+    def envelope_997(body)
+      <<~EDI.gsub("\n", "~")
+        ISA*00*          *00*          *ZZ*SENDER         *ZZ*RECEIVER       *230101*1200*U*00501*000000001*0*P*>
+        GS*XX*SENDER*RECEIVER*20230101*1200*1*X*005010
+        ST*997*0001
+        #{body}
+        SE*99*0001
+        GE*1*1
+        IEA*1*000000001
+      EDI
+    end
+
+    it "binds CC to the post-inner-loop slot when the inner loop is consumed" do
+      machine, result = Stupidedi::Parser.build(interleaved_config)
+        .read(Stupidedi::Reader.build(envelope_997("AA*P\nBB*innervalue\nCC*beta")))
+
+      if result.fatal?
+        result.explain { |msg| fail "Parse error: #{msg}" }
+      end
+      expect(result).to be_success
+
+      cc = machine.first
+        .flatmap{|m| m.find(:GS) }
+        .flatmap{|m| m.find(:ST) }
+        .flatmap{|m| m.find(:AA) }
+        .flatmap{|m| m.find(:BB) }
+        .flatmap{|m| m.find(:CC) }
+        .fetch
+      expect(cc.zipper.fetch.node.usage.position).to eq(500)
+    end
+  end
+
+  # Direct unit tests on the helper that disambiguates duplicate sibling
+  # slots. Constructing a parser state where two same-id SegmentUses with
+  # *different* parents both survive ValueBased filtering is awkward and
+  # partner-grammar specific, so we pin the precondition logic with a unit
+  # test instead. LoopDef#build leaves children with `parent: nil`; we use
+  # LoopDef.new with a non-nil parent argument so the constructor's
+  # re-parenting block fires (see schema/loop_def.rb:35-37) and SegmentUse
+  # parents become the LoopDef instances.
+  context "ConstraintTable::ValueBased#disambiguate_sibling_slots" do
+    let(:stub_parent) { Object.new }
+
+    def make_instruction(segment_use)
+      Stupidedi::Parser::Instruction.new(:CC, segment_use, 0, 0, nil)
+    end
+
+    def make_table(instructions)
+      Stupidedi::Parser::ConstraintTable::ValueBased.new(instructions)
+    end
+
+    it "picks earliest position when survivors share a parent loop" do
+      shared_loop = d::LoopDef.new("LS", d::RepeatCount.bounded(1),
+        [cc_def.use(100, r::Optional, d::RepeatCount.bounded(1)),
+         cc_def.use(200, r::Optional, d::RepeatCount.bounded(1))],
+        stub_parent)
+
+      early_use = shared_loop.children.at(0)
+      late_use  = shared_loop.children.at(1)
+
+      expect(early_use.parent).to be(shared_loop)
+      expect(late_use.parent).to  be(shared_loop)
+
+      early = make_instruction(early_use)
+      late  = make_instruction(late_use)
+
+      result = make_table([early, late]).send(:disambiguate_sibling_slots, [early, late])
+      expect(result).to contain_exactly(early)
+    end
+
+    it "returns input unchanged when survivors are in different parent loops" do
+      loop_a = d::LoopDef.new("LA", d::RepeatCount.bounded(1),
+        [cc_def.use(100, r::Optional, d::RepeatCount.bounded(1))], stub_parent)
+      loop_b = d::LoopDef.new("LB", d::RepeatCount.bounded(1),
+        [cc_def.use(200, r::Optional, d::RepeatCount.bounded(1))], stub_parent)
+
+      use_a = loop_a.children.at(0)
+      use_b = loop_b.children.at(0)
+
+      expect(use_a.parent).not_to be(use_b.parent)
+
+      instr_a = make_instruction(use_a)
+      instr_b = make_instruction(use_b)
+
+      result = make_table([instr_a, instr_b]).send(:disambiguate_sibling_slots, [instr_a, instr_b])
+      expect(result).to contain_exactly(instr_a, instr_b)
+    end
+  end
+end


### PR DESCRIPTION
When a LoopDef contained two structurally-identical SegmentUse slots (same segment id, no qualifier element) and the input filled only the earlier slot, the parser aborted with "too much non-determinism" — first observed downstream as a Home Depot 4010 PO850 with two N3 slots in the partner-customised N1 loop.

ConstraintTable::ValueBased now consults the active parser state's parse tree to pick the slot whose preceding sibling has actually been consumed (Variant A — structural reachability). The active AbstractState is plumbed through InstructionTable#matches and the ConstraintTable subclasses' matches. Behaviour is unchanged for qualifier-disambiguated paths (e.g. N1 by N101) and for genuinely ambiguous cases across different parent loops; the :insert gate skips disambiguation during :find navigation.

Adds spec/lib/stupidedi/parser/duplicate_slot_spec.rb with a synthetic grammar covering: earlier-only, later-via-in-loop-opener, both blocks, ambiguous-across-parents (preserves the existing non-determinism error), and an interleaved child loop between sibling slots (locks in the InstructionTable#drop_count interaction that prunes earlier candidates upstream).