### PR TITLE
Create GitHub release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,13 @@
+# Group changes in release notes using PR tags
+changelog:
+  categories:
+    - title: Breaking Changes
+      labels: [breaking]
+    - title: New Features
+      labels: [enhancement]
+    - title: Bug Fixes
+      labels: [bug, defect]
+    - title: Maintenance
+      labels: [maintenance]
+    - title: Other Changes
+      labels: ["*"]

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,3 +33,12 @@ jobs:
 
       - run: gem build *.gemspec
       - run: gem push *.gem
+      - uses: actions/github-script@v9
+        with:
+          script: |
+            await github.rest.repos.createRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag_name: context.ref.replace('refs/tags/', ''),
+              generate_release_notes: true,
+            });


### PR DESCRIPTION
Create GitHub releases with auto-generated release notes (after publishing the gem) when tags are pushed