### PR TITLE
Remove term-ansicolor dependency

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -1,6 +1,5 @@
 require "base64"
 require "simplecov-inline-html"
-require "term/ansicolor"
 
 SimpleCov.start do
   coverage_dir "build/generated/coverage"
@@ -40,6 +39,9 @@ class SimpleCov::Formatter::SummaryFormatter
     print_group("SUMMARY", result.files, name_width, count_width)
   end
 
+  # ANSI SGR (Select Graphic Rendition) codes for the three colors used here
+  ANSI_CODES = { :green => 32, :yellow => 33, :red => 31 }
+
   def print_group(name, files, name_width, count_width)
     pct = files.covered_percent
     clr = case pct
@@ -47,11 +49,11 @@ class SimpleCov::Formatter::SummaryFormatter
           when 80..90  then :yellow
           else              :red
           end
-    puts Term::ANSIColor.send(clr,
-      ("  % #{name_width}s: % 5s%%      " +
+    text = ("  % #{name_width}s: % 5s%%      " +
        "% #{count_width}s missed lines, " +
        "% #{count_width + 2}s lines total") %
-       [name, pct.round(1), files.missed_lines.to_i, files.lines_of_code.to_i])
+       [name, pct.round(1), files.missed_lines.to_i, files.lines_of_code.to_i]
+    puts "\e[#{ANSI_CODES.fetch(clr)}m#{text}\e[0m"
   end
 end
 

--- a/bin/edi-ed
+++ b/bin/edi-ed
@@ -6,7 +6,7 @@ require "stupidedi"
 require "pp"
 
 # This will be auto-enabled when $stdout.tty?, but -C forces color output
-require "term/ansicolor" if ARGV.delete("-C")
+Stupidedi::Color.enabled = true if ARGV.delete("-C")
 
 config = Stupidedi::Config.hipaa
 config.editor.tap do |c|

--- a/bin/edi-pp
+++ b/bin/edi-pp
@@ -3,7 +3,7 @@ require File.expand_path("../../lib/stupidedi", __FILE__)
 require "pp"
 
 # This will be auto-enabled when $stdout.tty?, but -C forces color output
-require "term/ansicolor" if ARGV.delete("-C")
+Stupidedi::Color.enabled = true if ARGV.delete("-C")
 if idx = ARGV.index("--format")
   ARGV.delete("--format")
   format = ARGV.delete_at(idx)

--- a/lib/stupidedi.rb
+++ b/lib/stupidedi.rb
@@ -4,12 +4,6 @@ require "time"
 require "date"
 require "set"
 
-begin
-  require "term/ansicolor" if $stdout.tty?
-rescue LoadError
-  warn "terminal color disabled. gem install term-ansicolor to enable"
-end
-
 $:.unshift(File.expand_path("..", __FILE__))
 
 require "ruby/array"

--- a/lib/stupidedi/color.rb
+++ b/lib/stupidedi/color.rb
@@ -4,12 +4,19 @@ module Stupidedi
 
   module Color
     def self.ansi
-      @__ansi ||=
-        if defined?(::Term::ANSIColor)
-          Wrapper.new(::Term::ANSIColor)
-        else
-          Wrapper.new(Stub)
-        end
+      @__ansi ||= Wrapper.new(enabled? ? ANSI : Stub)
+    end
+
+    # True if output should be colorized. Defaults to whether stdout is
+    # attached to a terminal, but can be forced on (eg, `-C` command line
+    # flag) or off.
+    def self.enabled?
+      @__enabled = $stdout.tty? if @__enabled.nil?
+      @__enabled
+    end
+
+    def self.enabled=(boolean)
+      @__enabled = boolean
     end
 
     def ansi
@@ -17,15 +24,43 @@ module Stupidedi
     end
 
     # @private
+    #
+    # No-op implementation used when colorized output is disabled.
     module Stub
-      METHODS = %w(bold clear reset dark underscore blink negative concealed
-                   black red green yellow blue magenta cyan white on_black
-                   on_red on_green on_yellow on_blue on_magenta on_cyan on_white)
+      METHODS = %w(bold dark black red yellow magenta white)
 
       METHODS.each do |name|
         instance_eval(<<-RUBY, __FILE__, __LINE__)
           def #{name}(string)
             string
+          end
+        RUBY
+      end
+    end
+
+    # @private
+    #
+    # Minimal implementation of the small subset of ANSI SGR (Select
+    # Graphic Rendition) escape codes that stupidedi actually uses to
+    # colorize pretty-printed output. This replaces the `term-ansicolor`
+    # gem dependency, which pulled in `tins`' global core-class
+    # monkeypatches (eg, redefining `Numeric#blank?` as `Numeric#zero?`)
+    # as an unwanted side effect.
+    module ANSI
+      CODES = {
+        "bold"    => 1,
+        "dark"    => 2,
+        "black"   => 30,
+        "red"     => 31,
+        "yellow"  => 33,
+        "magenta" => 35,
+        "white"   => 37,
+      }
+
+      CODES.each do |name, code|
+        instance_eval(<<-RUBY, __FILE__, __LINE__)
+          def #{name}(string)
+            "\e[#{code}m\#{string}\e[0m"
           end
         RUBY
       end

--- a/notes/output.rb
+++ b/notes/output.rb
@@ -6,7 +6,7 @@ require "stupidedi"
 require "pp"
 
 # This will be auto-enabled when $stdout.tty?, but -C forces color output
-require "term/ansicolor" if ARGV.delete("-C")
+Stupidedi::Color.enabled = true if ARGV.delete("-C")
 
 config = Stupidedi::Config.new
 config.interchange.tap do |c|

--- a/spec/lib/stupidedi/color_spec.rb
+++ b/spec/lib/stupidedi/color_spec.rb
@@ -24,10 +24,8 @@ describe Stupidedi::Color do
     include_examples "methods"
   end
 
-  if defined? Term::ANSIColor
-    describe "implementation" do
-      let(:wrapper) { Stupidedi::Color::Wrapper.new(Term::ANSIColor) }
-      include_examples "methods"
-    end
+  describe "implementation" do
+    let(:wrapper) { Stupidedi::Color::Wrapper.new(Stupidedi::Color::ANSI) }
+    include_examples "methods"
   end
 end

--- a/stupidedi.gemspec
+++ b/stupidedi.gemspec
@@ -32,8 +32,8 @@ Gem::Specification.new do |s|
   s.require_path      = "lib"
 
   s.required_ruby_version = ">= 3.2"
-  s.add_dependency "term-ansicolor", "~> 1.3"
   s.add_dependency "cantor",         "~> 1.2.1"
   s.add_dependency "bigdecimal"
   s.add_dependency "ostruct"
+  s.add_dependency "base64"
 end


### PR DESCRIPTION
The `term-ansicolor` gem depends on another gem named 'tins', which monkey-patches global methods (`blank?` or something) and breaks the test suite, among other things. This library was only loaded when `$stdin.is_tty?` is true, so it did not affect the CI.