### PR TITLE
Warn when replacing transaction set registrations

### DIFF
--- a/lib/stupidedi/config/transaction_set_config.rb
+++ b/lib/stupidedi/config/transaction_set_config.rb
@@ -27,10 +27,16 @@ module Stupidedi
 
       # @return [void]
       def register(gs08, gs01, st01, definition = nil, &constructor)
+        key = Array[gs08, gs01, st01]
+
+        if @table.key?(key)
+          warn "Transaction set #{key.inspect} is already registered; replacing it"
+        end
+
         if block_given?
-          @table[Array[gs08, gs01, st01]] = constructor
+          @table[key] = constructor
         else
-          @table[Array[gs08, gs01, st01]] = definition
+          @table[key] = definition
         end
       end
 

--- a/spec/lib/stupidedi/config/transaction_set_config_spec.rb
+++ b/spec/lib/stupidedi/config/transaction_set_config_spec.rb
@@ -1,0 +1,21 @@
+describe Stupidedi::Config::TransactionSetConfig do
+  describe "#register" do
+    it "warns before replacing an existing transaction set" do
+      config = described_class.new
+      original = Object.new
+      replacement = Object.new
+
+      expect do
+        config.register("004010", "SM", "204") { original }
+      end.not_to output.to_stderr
+
+      expect do
+        config.register("004010", "SM", "204") { replacement }
+      end.to output(
+        "Transaction set [\"004010\", \"SM\", \"204\"] is already registered; replacing it\n"
+      ).to_stderr
+
+      expect(config.at("004010", "SM", "204")).to be(replacement)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- warn before an existing transaction-set registration is replaced
- include the GS08/ST03, GS01, and ST01 tuple in the warning
- preserve replacement behavior and cover it with a focused regression spec

## Why

Registering the same transaction-set tuple twice currently overwrites the first entry without any indication. This makes an accidental standards/implementation-guide collision difficult to notice.

Fixes #8.

## Validation

- `bundle exec rspec -I lib -rspec_helper spec/lib/stupidedi/config/transaction_set_config_spec.rb` (1 example, 0 failures)
- `bundle exec rake` (2,510 examples, 0 failures, 90 existing pending examples)
- Ruby syntax checks for both changed files
- direct-definition registration and replacement probe
- `git diff --check`
